### PR TITLE
Add IIO device buffer support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install Arm GNU Toolchain (arm-none-eabi-gcc)
-      uses: carlosperate/arm-none-eabi-gcc-action@v1
+      # Using custom version while the upstream is broken. See:
+      #
+      #   https://github.com/carlosperate/arm-none-eabi-gcc-action/issues/74
+      #
+      # When the issue is resolved, we should change back to:
+      #
+      #   uses: carlosperate/arm-none-eabi-gcc-action@v1
+      uses: sevenlab-de/arm-none-eabi-gcc-action@redir_packaged
       with:
         release: '14.2.Rel1'
 

--- a/TODO.md
+++ b/TODO.md
@@ -23,7 +23,5 @@
     - `DLN2_GPIO_EVENT_LVL_LOW`
     - How to test? Not supported by gpiod tools.
     - I assume we can handle them the same way as edge triggered irqs, so we'll just send a trigger when the value changes to the target value. The only difference being that if the irq event enable is requested and the target value is already present, we should also send a trigger immediately.
-- ADC
-  - buffers so we can use iio-tools
 - SPI
   - TODO

--- a/docs/usage_adc.md
+++ b/docs/usage_adc.md
@@ -5,20 +5,60 @@ The ADC is registered as an IIO (industrial I/O) device.
 Example: Analog read of GP26/ADC0 (in volt; using IIO device `iio:device0`)
 
 ```bash
-echo "$(cat /sys/bus/iio/devices/iio:device0/in_voltage0_raw) * $(cat /sys/bus/iio/devices/iio:device0/scale)" | bc
+echo "$(cat /sys/bus/iio/devices/iio\:device0/in_voltage0_raw) * $(cat /sys/bus/iio/devices/iio\:device0/scale)" | bc
 ```
 
 Special case: Analog read of Pico VSYS (in volt; using IIO device `iio:device0`)
 
 ```bash
-echo "$(cat /sys/bus/iio/devices/iio:device0/in_voltage3_raw) * $(cat /sys/bus/iio/devices/iio:device0/scale) * 3" | bc
+echo "$(cat /sys/bus/iio/devices/iio\:device0/in_voltage3_raw) * $(cat /sys/bus/iio/devices/iio\:device0/scale) * 3" | bc
 ```
 
 Special case: Analog read of Pico onboard temperature sensor (in degree Celsius; formula according
 to Pico datasheet; using IIO device `iio:device0`)
 
 ```bash
-echo "27.0 - ($(cat /sys/bus/iio/devices/iio:device0/in_voltage4_raw) * $(cat /sys/bus/iio/devices/iio:device0/scale) - 0.706) / 0.001721" | bc
+echo "27.0 - ($(cat /sys/bus/iio/devices/iio\:device0/in_voltage4_raw) * $(cat /sys/bus/iio/devices/iio\:device0/scale) - 0.706) / 0.001721" | bc
+```
+
+Example: Multiple analog reads of GP26/ADC0 and GP28/ADC2 (using IIO device `iio:device0` with 20 Hz
+sampling frequency)
+
+Note: The values are in binary format, described by "le:u10/16>>0", see Kernel documentation for
+["Industrial IIO device buffers" > "Scan Elements" > "_type"](https://docs.kernel.org/iio/iio_devbuf.html#scan-elements),
+i.e., they are unsigned 16 bit integers in little-endian format and only the lower 10 bit are used.
+
+Option 1: Use the tools provided by the package `iiod` and `libiio-utils`
+
+```bash
+sudo apt install iiod libiio-utils
+```
+
+```bash
+iio_attr --uri=ip:127.0.0.1 -d iio:device0 sampling_frequency 20
+iio_readdev --uri=ip:127.0.0.1 --samples=10 --buffer-size=32 --timeout=0 iio:device0 voltage0 voltage2 | hexdump -v
+# Example output:
+#   0000000 0005 01fd 0005 01fd 0005 01fd 0005 01fd
+#   0000010 0005 01fd 0005 01fd 0005 01fd 0005 01fd
+#   0000020 0005 01fd 0005 01fd
+#   0000028
+```
+
+Note: For application use, there are multiple other bindings for libiio, e.g., Python, Rust, C#...
+
+Option 2: The same can be achieved just via `/sys` (requires root access):
+
+```bash
+echo 20 > /sys/bus/iio/devices/iio\:device0/sampling_frequency
+# Enable GP26/ADC0 and GP28/ADC2
+echo 1 > /sys/bus/iio/devices/iio\:device0/scan_elements/in_voltage0_en
+echo 1 > /sys/bus/iio/devices/iio\:device0/scan_elements/in_voltage2_en
+# Start sampling
+echo 1 > /sys/bus/iio/devices/iio\:device0/buffer/enable
+# Read values
+hexdump -v /dev/iio\:device0
+# Stop sampling
+echo 0 > /sys/bus/iio/devices/iio\:device0/buffer/enable
 ```
 
 ADC pin assignment (voltage index is the `X` in `in_voltageX_raw`):
@@ -26,5 +66,3 @@ ADC pin assignment (voltage index is the `X` in `in_voltageX_raw`):
 | Pico Pin                  | GP26/ADC0 | GP27/ADC1 | GP28/ADC2 | (VSYS/3) | (temp. raw) |
 |---------------------------|-----------|-----------|-----------|----------|-------------|
 | voltage index             |         0 |         1 |         2 |        3 |           4 |
-
-Note: The buffer functionality is not implemented yet.

--- a/src/dln2.h
+++ b/src/dln2.h
@@ -34,6 +34,14 @@
 #define DLN2_ADC_CHANNEL_GET_CFG	DLN2_CMD(0x0D, DLN2_ADC_ID)
 #define DLN2_ADC_CONDITION_MET_EV	DLN2_CMD(0x10, DLN2_ADC_ID)
 
+#define DLN2_ADC_EVENT_NONE		0
+#define DLN2_ADC_EVENT_BELOW		1
+#define DLN2_ADC_EVENT_LEVEL_ABOVE	2
+#define DLN2_ADC_EVENT_OUTSIDE		3
+#define DLN2_ADC_EVENT_INSIDE		4
+#define DLN2_ADC_EVENT_ALWAYS		5
+
+#define DLN2_ADC_MAX_CHANNELS 8
 #define DLN2_ADC_DATA_BITS 10
 
 // --- End of defines from Linux drivers/iio/adc/dln2-adc.c ---

--- a/src/main.c
+++ b/src/main.c
@@ -37,6 +37,10 @@ void vApplicationIdleHook(void)
 		xTaskResumeAll();
 
 		vTaskSuspendAll();
+		pp_adc_task();
+		xTaskResumeAll();
+
+		vTaskSuspendAll();
 		send_delayed_messages();
 		xTaskResumeAll();
 	}
@@ -137,7 +141,6 @@ static bool handle_rx_data(const uint8_t *buf_in, uint16_t buf_in_size)
 
 	TU_LOG3("main: Request to handle %u (%s): command %u (size=%u, echo=%u)\r\n",
 		handle, handle2str(handle), id, size, echo);
-	(void)echo;
 
 	const uint8_t *data_in = &buf_in[MSG_HDR_SZ];
 	uint16_t data_in_len = buf_in_size - MSG_HDR_SZ;

--- a/src/pp_adc.c
+++ b/src/pp_adc.c
@@ -9,6 +9,7 @@
 
 #include "byte_ops.h"
 #include "dln2.h"
+#include "main.h"
 
 static const uint8_t adc_gpios[] = {
 	26, 27, 28,
@@ -17,7 +18,8 @@ static const uint8_t adc_gpios[] = {
 };
 
 #define NUM_PP_ADC_CHANNELS (TU_ARRAY_SIZE(adc_gpios) + 1)
-#define ADC_OFFS (NUM_ADC_CHANNELS - NUM_PP_ADC_CHANNELS)
+
+TU_VERIFY_STATIC(NUM_PP_ADC_CHANNELS <= DLN2_ADC_MAX_CHANNELS);
 
 static const char *adc_cmd2str(uint16_t cmd)
 {
@@ -32,11 +34,36 @@ static const char *adc_cmd2str(uint16_t cmd)
 	case DLN2_ADC_CHANNEL_GET_VAL: return "CHANNEL_GET_VAL";
 	case DLN2_ADC_CHANNEL_GET_ALL_VAL: return "CHANNEL_GET_ALL_VAL";
 	case DLN2_ADC_CHANNEL_SET_CFG: return "CHANNEL_SET_CFG";
-	case DLN2_ADC_CHANNEL_GET_CFG: return "CHANNEL_GET_CFG";
+	case DLN2_ADC_CHANNEL_GET_CFG: return "CHANNEL_GET_CFG"; /* Unused by kernel driver */
 	case DLN2_ADC_CONDITION_MET_EV: return "CONDITION_MET_EV";
 	default: return "???";
 	}
 	// clang-format on
+}
+
+struct {
+	enum {
+		PP_ADC_MODE_IDLE = 0,
+		PP_ADC_MODE_ACTIVE,
+		PP_ADC_MODE_ACTIVE_STREAMING,
+	} mode;
+
+	uint8_t channel_mask;
+	uint16_t samples[NUM_PP_ADC_CHANNELS];
+
+	uint64_t period_us;
+	uint64_t next_sample_time_us;
+} pp_adc;
+
+static uint16_t pp_adc_read(uint8_t chan)
+{
+	adc_select_input(chan);
+	uint16_t val = adc_read();
+
+	// Pico has 12-bit ADC, kernel driver expects 10-bit ADC
+	val = val >> 2;
+
+	return val;
 }
 
 bool pp_adc_handle_request(uint16_t cmd, uint8_t const *data_in,
@@ -63,23 +90,37 @@ bool pp_adc_handle_request(uint16_t cmd, uint8_t const *data_in,
 		break;
 	case DLN2_ADC_CHANNEL_ENABLE: {
 		TU_VERIFY(data_in_len >= 2);
-		uint8_t chan = data_in[1] + ADC_OFFS;
+		uint8_t chan = data_in[1];
 		TU_LOG3("ADC: Enabling channel %u\r\n", chan);
-		(void)chan;
+		if (pp_adc.mode != PP_ADC_MODE_IDLE) {
+			TU_LOG1("ADC: Failed to enable channel. Device is busy.\r\n");
+			return false;
+		}
+		pp_adc.channel_mask |= (1 << chan);
 		*data_out_len = 0;
 		break;
 	}
 	case DLN2_ADC_CHANNEL_DISABLE: {
 		TU_VERIFY(data_in_len >= 2);
-		uint8_t chan = data_in[1] + ADC_OFFS;
+		uint8_t chan = data_in[1];
 		TU_LOG3("ADC: Disabling channel %u\r\n", chan);
 		(void)chan;
+		if (pp_adc.mode != PP_ADC_MODE_IDLE) {
+			TU_LOG1("ADC: Failed to disable channel. Device is busy.\r\n");
+			return false;
+		}
+		pp_adc.channel_mask &= ~(1 << chan);
 		*data_out_len = 0;
 		break;
 	}
 	case DLN2_ADC_ENABLE: {
 		TU_ASSERT(*data_out_len >= 2);
 		TU_LOG3("ADC: Enabling\r\n");
+		if (pp_adc.mode != PP_ADC_MODE_IDLE) {
+			TU_LOG1("ADC: Failed to enable. Device is busy.\r\n");
+			return false;
+		}
+		pp_adc.mode = PP_ADC_MODE_ACTIVE;
 		u16_to_buf_le(&data_out[0], 0); // no conflict
 		*data_out_len = 2;
 		break;
@@ -87,6 +128,11 @@ bool pp_adc_handle_request(uint16_t cmd, uint8_t const *data_in,
 	case DLN2_ADC_DISABLE: {
 		TU_ASSERT(*data_out_len >= 2);
 		TU_LOG3("ADC: Disabling\r\n");
+		if (pp_adc.mode == PP_ADC_MODE_ACTIVE_STREAMING) {
+			TU_LOG1("ADC: Failed to disable. Device is streaming.\r\n");
+			return false;
+		}
+		pp_adc.mode = PP_ADC_MODE_IDLE;
 		u16_to_buf_le(&data_out[0], 0); // no conflict
 		*data_out_len = 2;
 		break;
@@ -94,14 +140,80 @@ bool pp_adc_handle_request(uint16_t cmd, uint8_t const *data_in,
 	case DLN2_ADC_CHANNEL_GET_VAL: {
 		TU_VERIFY(data_in_len >= 2);
 		TU_ASSERT(*data_out_len >= 2);
-		uint8_t chan = data_in[1] + ADC_OFFS;
-		adc_select_input(chan);
-		uint16_t val = adc_read();
-		// Pico has 12-bit ADC, kernel driver expects 10-bit ADC
-		val = val >> 2;
+		if (pp_adc.mode != PP_ADC_MODE_ACTIVE) {
+			TU_LOG1("ADC: Failed to get value. Device not enabled or busy.\r\n");
+			return false;
+		}
+		uint8_t chan = data_in[1];
+		uint16_t val = pp_adc_read(chan);
 		TU_LOG3("ADC: Getting channel %u value: %u\r\n", chan, val);
 		u16_to_buf_le(&data_out[0], val);
 		*data_out_len = 2;
+		break;
+	}
+	case DLN2_ADC_CHANNEL_GET_ALL_VAL: {
+		TU_LOG3("ADC: DLN2_ADC_CHANNEL_GET_ALL_VAL\r\n");
+		TU_ASSERT(*data_out_len >= 2 + 2 * DLN2_ADC_MAX_CHANNELS);
+
+		u16_to_buf_le(&data_out[0], 0); // unused by kernel driver
+
+		int i;
+		for (i = 0; i < NUM_PP_ADC_CHANNELS; i++) {
+			u16_to_buf_le(&data_out[2 + 2 * i], pp_adc.samples[i]);
+		}
+		/* continuing */
+		for (; i < DLN2_ADC_MAX_CHANNELS; i++) {
+			u16_to_buf_le(&data_out[2 + 2 * i], 0);
+		}
+
+		*data_out_len = 2 + 2 * DLN2_ADC_MAX_CHANNELS;
+		break;
+	}
+	case DLN2_ADC_CHANNEL_SET_CFG: {
+		TU_VERIFY(data_in_len >= 5);
+		// We don't need channel or type.
+		uint16_t new_period_ms = u16_from_buf_le(&data_in[3]);
+		TU_LOG3("ADC: Setting config (period=%" PRIu16 "ms)\r\n",
+			new_period_ms);
+
+		switch (pp_adc.mode) {
+		case PP_ADC_MODE_IDLE:
+			TU_LOG1("ADC: Setting config ignored. Device idle.\r\n");
+			break;
+		case PP_ADC_MODE_ACTIVE:
+			if (new_period_ms != 0) {
+				TU_LOG3("ADC: Start streaming (channel mask=0x%02" PRIx8
+					")\r\n",
+					pp_adc.channel_mask);
+
+				pp_adc.period_us =
+					(uint64_t)new_period_ms * 1000;
+
+				uint64_t now =
+					to_us_since_boot(get_absolute_time());
+				pp_adc.next_sample_time_us =
+					now + pp_adc.period_us;
+
+				memset(pp_adc.samples, 0,
+				       sizeof(pp_adc.samples));
+
+				pp_adc.mode = PP_ADC_MODE_ACTIVE_STREAMING;
+			} else {
+				TU_LOG1("ADC: Not streaming. Sample rate is zero.\r\n");
+			}
+			break;
+		case PP_ADC_MODE_ACTIVE_STREAMING:
+			if (new_period_ms == 0) {
+				TU_LOG3("ADC: End streaming\r\n");
+
+				pp_adc.mode = PP_ADC_MODE_ACTIVE;
+			} else {
+				TU_LOG1("ADC: Cannot change sample rate during streaming.\r\n");
+				return false;
+			}
+			break;
+		}
+		*data_out_len = 0;
 		break;
 	}
 	default:
@@ -111,6 +223,28 @@ bool pp_adc_handle_request(uint16_t cmd, uint8_t const *data_in,
 	}
 
 	return true;
+}
+
+void pp_adc_task(void)
+{
+	uint64_t now = to_us_since_boot(get_absolute_time());
+	if (pp_adc.mode == PP_ADC_MODE_ACTIVE_STREAMING &&
+	    now > pp_adc.next_sample_time_us) {
+		for (uint8_t chan = 0; chan < NUM_PP_ADC_CHANNELS; chan++) {
+			if (((1 << chan) & pp_adc.channel_mask) == 0)
+				continue;
+
+			pp_adc.samples[chan] = pp_adc_read(chan);
+		}
+
+		// unsolicited message, so no echo code
+		send_message_delayed(DLN2_ADC_CONDITION_MET_EV, 0,
+				     DLN2_HANDLE_EVENT, NULL, 0);
+
+		while (now > pp_adc.next_sample_time_us) {
+			pp_adc.next_sample_time_us += pp_adc.period_us;
+		}
+	}
 }
 
 void pp_adc_init(void)

--- a/src/pp_adc.c
+++ b/src/pp_adc.c
@@ -43,24 +43,26 @@ bool pp_adc_handle_request(uint16_t cmd, uint8_t const *data_in,
 			   uint16_t data_in_len, uint8_t *data_out,
 			   uint16_t *data_out_len)
 {
+	TU_VERIFY(data_in_len >= 1);
+
+	uint8_t port = data_in[0];
+	TU_VERIFY(port == 0); // always 0 in kernel driver
+
 	switch (cmd) {
 	case DLN2_ADC_GET_CHANNEL_COUNT:
 		TU_ASSERT(*data_out_len >= 1);
-		TU_VERIFY(data_in_len == 1);
-		TU_VERIFY(data_in[0] == 0);
 		TU_LOG3("ADC: Getting number of channels\r\n");
 		data_out[0] = NUM_PP_ADC_CHANNELS;
 		*data_out_len = 1;
 		break;
 	case DLN2_ADC_SET_RESOLUTION:
-		TU_VERIFY(data_in_len == 2);
-		TU_VERIFY(data_in[0] == 0 && data_in[1] == DLN2_ADC_DATA_BITS);
+		TU_VERIFY(data_in_len >= 2);
+		TU_VERIFY(data_in[1] == DLN2_ADC_DATA_BITS);
 		TU_LOG3("ADC: Setting resolution\r\n");
 		*data_out_len = 0;
 		break;
 	case DLN2_ADC_CHANNEL_ENABLE: {
-		TU_VERIFY(data_in_len == 2);
-		TU_VERIFY(data_in[0] == 0);
+		TU_VERIFY(data_in_len >= 2);
 		uint8_t chan = data_in[1] + ADC_OFFS;
 		TU_LOG3("ADC: Enabling channel %u\r\n", chan);
 		(void)chan;
@@ -68,8 +70,7 @@ bool pp_adc_handle_request(uint16_t cmd, uint8_t const *data_in,
 		break;
 	}
 	case DLN2_ADC_CHANNEL_DISABLE: {
-		TU_VERIFY(data_in_len == 2);
-		TU_VERIFY(data_in[0] == 0);
+		TU_VERIFY(data_in_len >= 2);
 		uint8_t chan = data_in[1] + ADC_OFFS;
 		TU_LOG3("ADC: Disabling channel %u\r\n", chan);
 		(void)chan;
@@ -78,8 +79,6 @@ bool pp_adc_handle_request(uint16_t cmd, uint8_t const *data_in,
 	}
 	case DLN2_ADC_ENABLE: {
 		TU_ASSERT(*data_out_len >= 2);
-		TU_VERIFY(data_in_len == 1);
-		TU_VERIFY(data_in[0] == 0);
 		TU_LOG3("ADC: Enabling\r\n");
 		u16_to_buf_le(&data_out[0], 0); // no conflict
 		*data_out_len = 2;
@@ -87,17 +86,14 @@ bool pp_adc_handle_request(uint16_t cmd, uint8_t const *data_in,
 	}
 	case DLN2_ADC_DISABLE: {
 		TU_ASSERT(*data_out_len >= 2);
-		TU_VERIFY(data_in_len == 1);
-		TU_VERIFY(data_in[0] == 0);
 		TU_LOG3("ADC: Disabling\r\n");
 		u16_to_buf_le(&data_out[0], 0); // no conflict
 		*data_out_len = 2;
 		break;
 	}
 	case DLN2_ADC_CHANNEL_GET_VAL: {
+		TU_VERIFY(data_in_len >= 2);
 		TU_ASSERT(*data_out_len >= 2);
-		TU_VERIFY(data_in_len == 2);
-		TU_VERIFY(data_in[0] == 0);
 		uint8_t chan = data_in[1] + ADC_OFFS;
 		adc_select_input(chan);
 		uint16_t val = adc_read();

--- a/src/pp_adc.h
+++ b/src/pp_adc.h
@@ -5,10 +5,10 @@
 #ifndef _PICOPORTS_PP_ADC_H_
 #define _PICOPORTS_PP_ADC_H_
 
+void pp_adc_init(void);
+void pp_adc_task(void);
 bool pp_adc_handle_request(uint16_t cmd, uint8_t const *data_in,
 			   uint16_t data_in_len, uint8_t *data_out,
 			   uint16_t *data_out_len);
-
-void pp_adc_init(void);
 
 #endif /* _PICOPORTS_PP_ADC_H_ */


### PR DESCRIPTION
Enable the iio buffer interface. This uses two more commands that are not used in single-read operation and were not implemented yet.