### PR TITLE
Add `usb_modeswitch` firmware upgrade trigger

### DIFF
--- a/60-dln2-plugdev-access.rules
+++ b/60-dln2-plugdev-access.rules
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (c) 2026 sevenlab engineering GmbH
+#
+# Add read-write permissions to all picoports / dln2 devices.
+
+ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="a257", ATTRS{idProduct}=="2013", GROUP="plugdev", MODE="0660"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ target_include_directories(picoports PUBLIC
 )
 
 target_link_libraries(picoports PUBLIC
+  pico_bootrom
   pico_stdlib
   hardware_adc
   hardware_i2c
@@ -59,7 +60,6 @@ endif()
 
 option(BOOTSEL_BUTTON "Pressing the button resets the pico into BOOTSEL mode")
 if(BOOTSEL_BUTTON)
-target_link_libraries(picoports PUBLIC pico_bootrom)
 target_compile_definitions(picoports PUBLIC PP_BTN_BOOTSEL=1)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Original image from [official Raspberry Pi documentation](https://datasheets.ras
    2. Plug the Pico into your PC, the Pico will open as thumb drive
    3. Copy the firmware onto the Pico thumb drive
 
+A running PicoPorts device (firmware v2.2.0 or newer) can also be switched into firmware
+upgrade mode [using `scripts/picoports_firmware_upgrade.py`](/docs/dev_setup.md#reset-into-boot-select-mode).
+
 ## Development
 
 See [Development Setup](./docs/dev_setup.md)

--- a/docs/dev_setup.md
+++ b/docs/dev_setup.md
@@ -27,6 +27,30 @@ cp build/picoports.uf2 /media/$USER/RPI-RP2/
   flash accesses, which interferes with the SWD capabilities. The host software may occasionally
   show warnings and errors when this is enabled.
 
+## Reset into boot select mode
+
+On Linux, a running PicoPorts device (with firmware version >= `v2.2.0`) can be switched into
+firmware upgrade mode using `usb_modeswitch`:
+
+```shell
+usb_modeswitch -v 0xa257 -p 0x2013 -b ${BUS} -g ${DEVICE} -i 0 -m 0x01 -M 4649524d5741524555504752414445
+```
+
+The message payload is the ASCII string `FIRMWAREUPGRADE`.
+
+A helper script is provided at `scripts/picoports_firmware_upgrade.py`. When executing this script
+it tries to reset an attached PicoPorts device into firmware upgrade mode. If more than one
+PicoPorts device is attached, the USB serial number must be provided.
+
+This feature needs privileged access on the host. The udev rule `60-dln2-plugdev-access.rules`
+grants this for all users in the `plugdev` group. You can install it with:
+
+```bash
+sudo cp 60-dln2-plugdev-access.rules /etc/udev/rules.d/
+sudo udevadm control --reload
+sudo udevadm trigger
+```
+
 ## Theory of operation
 
 PicoPorts works without a custom driver, because it's using a driver that already exists. The driver

--- a/scripts/picoports_firmware_upgrade.py
+++ b/scripts/picoports_firmware_upgrade.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (c) 2026 sevenlab engineering GmbH
+#
+"""Switch a PicoPorts device into USB firmware upgrade mode."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+PICO_PORTS_VID = "a257"
+PICO_PORTS_PID = "2013"
+PICO_PORTS_DLN2_INTERFACE = "0"
+PICO_PORTS_DLN2_OUT_ENDPOINT = "0x01"
+FIRMWARE_UPGRADE_MAGIC_HEX = "4649524d5741524555504752414445"  # hex of FIRMWAREUPGRADE
+
+
+@dataclass(frozen=True)
+class UsbDevice:
+    path: Path
+    busnum: int
+    devnum: int
+    serial: str
+    manufacturer: str
+    product: str
+
+    def __str__(self) -> str:
+        serial = self.serial or "<no serial>"
+        product = self.product or "<no product>"
+        return ", ".join(
+            [
+                f"path = {self.path.name}",
+                f"bus = {self.busnum}",
+                f"dev = {self.devnum}",
+                f"serial = {serial}",
+                f"{product}",
+            ]
+        )
+
+
+def read_sysfs_str(path: Path) -> str | None:
+    try:
+        return path.read_text(encoding="ascii").strip()
+    except OSError:
+        return None
+
+
+def read_sysfs_int(path: Path) -> int | None:
+    value = read_sysfs_str(path)
+    if value is None:
+        return None
+
+    try:
+        return int(value, 10)
+    except ValueError:
+        return None
+
+
+def find_picoports_devices(sysfs_root: Path) -> list[UsbDevice] | None:
+    devices: list[UsbDevice] = []
+
+    try:
+        paths = sysfs_root.iterdir()
+    except OSError as exc:
+        print(f"Cannot read USB sysfs root {sysfs_root}: {exc}", file=sys.stderr)
+        return None
+
+    for path in paths:
+        vid = read_sysfs_str(path / "idVendor")
+        pid = read_sysfs_str(path / "idProduct")
+        if vid is None or pid is None:
+            continue
+        if vid.lower() != PICO_PORTS_VID or pid.lower() != PICO_PORTS_PID:
+            continue
+
+        busnum = read_sysfs_int(path / "busnum")
+        devnum = read_sysfs_int(path / "devnum")
+        if busnum is None or devnum is None:
+            continue
+
+        devices.append(
+            UsbDevice(
+                path=path,
+                busnum=busnum,
+                devnum=devnum,
+                serial=read_sysfs_str(path / "serial") or "",
+                manufacturer=read_sysfs_str(path / "manufacturer") or "",
+                product=read_sysfs_str(path / "product") or "",
+            )
+        )
+
+    return sorted(devices, key=lambda device: (device.busnum, device.devnum))
+
+
+def select_device(devices: list[UsbDevice], serial: str | None) -> UsbDevice | None:
+    if serial is not None:
+        matches = [device for device in devices if device.serial == serial]
+        if len(matches) == 1:
+            return matches[0]
+        elif len(matches) > 1:
+            print(f"Multiple PicoPorts devices have serial {serial}", file=sys.stderr)
+        else:
+            print(f"No PicoPorts device with serial {serial} found", file=sys.stderr)
+    else:
+        if len(devices) == 1:
+            return devices[0]
+        elif len(devices) > 1:
+            print(
+                "Multiple PicoPorts devices found; pass a serial number",
+                file=sys.stderr,
+            )
+        else:
+            print("No PicoPorts devices found", file=sys.stderr)
+
+    if devices:
+        print("Detected PicoPorts devices:", file=sys.stderr)
+        for device in devices:
+            print(f"  {device}", file=sys.stderr)
+
+    return None
+
+
+def modeswitch_command(usb_modeswitch: str, device: UsbDevice) -> list[str]:
+    return [
+        usb_modeswitch,
+        "-v",
+        f"0x{PICO_PORTS_VID}",
+        "-p",
+        f"0x{PICO_PORTS_PID}",
+        "-b",
+        str(device.busnum),
+        "-g",
+        str(device.devnum),
+        "-i",
+        PICO_PORTS_DLN2_INTERFACE,
+        "-m",
+        PICO_PORTS_DLN2_OUT_ENDPOINT,
+        "-M",
+        FIRMWARE_UPGRADE_MAGIC_HEX,
+    ]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "serial",
+        nargs="?",
+        help="PicoPorts USB serial number; optional when exactly one device exists",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="list detected PicoPorts devices and exit",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print the usb_modeswitch command instead of running it",
+    )
+    # for testing
+    parser.add_argument(
+        "--sysfs-root",
+        default="/sys/bus/usb/devices",
+        type=Path,
+        help=argparse.SUPPRESS,
+    )
+    # for testing
+    parser.add_argument(
+        "--usb-modeswitch",
+        default="usb_modeswitch",
+        help=argparse.SUPPRESS,
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    devices = find_picoports_devices(args.sysfs_root)
+    if devices is None:
+        return 2  # ENOENT
+
+    if args.list:
+        for device in devices:
+            print(device)
+
+        return 0
+
+    device = select_device(devices, args.serial)
+    if device is None:
+        return 19  # ENODEV
+
+    command = modeswitch_command(args.usb_modeswitch, device)
+
+    print(f"Switching PicoPorts device: {device}")
+    if args.dry_run:
+        print(" ".join(command))
+        return 0
+
+    try:
+        return subprocess.run(command, check=False).returncode
+    except FileNotFoundError:
+        print(
+            f"usb_modeswitch command not found: {args.usb_modeswitch}",
+            file=sys.stderr,
+        )
+        return 2  # ENOENT
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/main.c
+++ b/src/main.c
@@ -4,10 +4,13 @@
  */
 #include "tusb.h"
 
+#include <string.h>
+
 #include "FreeRTOS.h"
 #include "task.h"
 
 #include "bsp/board_api.h"
+#include "pico/bootrom.h"
 
 #include "byte_ops.h"
 #include "dln2.h"
@@ -17,6 +20,16 @@
 #include "pp_i2c.h"
 
 static void send_delayed_messages(void);
+
+#define FIRMWARE_UPGRADE_MAGIC "FIRMWAREUPGRADE"
+#define FIRMWARE_UPGRADE_MAGIC_LEN (sizeof(FIRMWARE_UPGRADE_MAGIC) - 1)
+
+static bool is_firmware_upgrade_request(const uint8_t *buf, uint16_t buf_size)
+{
+	return buf_size == FIRMWARE_UPGRADE_MAGIC_LEN &&
+	       memcmp(buf, FIRMWARE_UPGRADE_MAGIC,
+		      FIRMWARE_UPGRADE_MAGIC_LEN) == 0;
+}
 
 void picoports_init(void)
 {
@@ -199,6 +212,11 @@ void tud_vendor_rx_cb(uint8_t itf, const uint8_t *buf_in, uint16_t buf_in_size)
 
 	if (itf != 0)
 		goto out;
+
+	if (is_firmware_upgrade_request(buf_in, buf_in_size)) {
+		tud_vendor_n_read_flush(itf);
+		rom_reset_usb_boot_extra(-1, 0, 0);
+	}
 
 	handle_rx_data(buf_in, buf_in_size);
 

--- a/src/main.c
+++ b/src/main.c
@@ -194,12 +194,14 @@ static bool handle_rx_data(const uint8_t *buf_in, uint16_t buf_in_size)
 
 void tud_vendor_rx_cb(uint8_t itf, const uint8_t *buf_in, uint16_t buf_in_size)
 {
-	(void)itf;
-
 	TU_LOG3("main: buf_in = ");
 	TU_LOG3_BUF(buf_in, buf_in_size);
 
+	if (itf != 0)
+		goto out;
+
 	handle_rx_data(buf_in, buf_in_size);
 
-	tud_vendor_read_flush();
+out:
+	tud_vendor_n_read_flush(itf);
 }

--- a/src/tusb_config.h
+++ b/src/tusb_config.h
@@ -7,8 +7,10 @@
 
 #include "dln2.h"
 
+// TinyUSB names the Raspberry Pi RP-series USB backend OPT_MCU_RP2040.
+// That backend is used for both Pico 1 and Pico 2 builds.
 #if CFG_TUSB_MCU != OPT_MCU_RP2040
-#error Only rp2040 is supported!
+#error PicoPorts requires the TinyUSB Raspberry Pi RP-series USB backend
 #endif
 
 #define CFG_TUSB_RHPORT0_MODE OPT_MODE_DEVICE


### PR DESCRIPTION
Allows reflashing a picoports device without manual intervention on the hardware (unplug, press button, plug in), by entering the firmware upgrade mode via `usb_modeswitch`.